### PR TITLE
Updated Groovy version from 2.3.7 to 2.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>[2.3.7]</version>
+      <version>[2.4.12]</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
There was a fix to groovydoc generation shipped in 2.4.8 and described in [GROOVY-7947](https://issues.apache.org/jira/browse/GROOVY-7497).

I would like to update the [groovydoc-maven-plugin](https://github.com/rvowles/groovydoc-maven-plugin) to include this fix. Therefore, this library (which gives the groovydoc-maven-plugin its groovy version) must be updated.

I have built snapshots of both of these and tested them - and my groovydoc then contained all of the methods (instead of just the last one).

If I understand the structure of the `groovydoc-maven-plugin` correctly, it can be released without a code change once a new version of `composite-groovy` is on maven-central, and it will pick up the latest `composite-groovy` artifact - so I'll raise an issue there, once `composite-groovy:1.5` hits maven-central.